### PR TITLE
Resolved Issue #211

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -68,7 +68,7 @@ export default [
       'vue/no-template-target-blank': 'error',
       'vue/no-undef-components': 'error',
       'vue/no-undef-properties': 'error',
-      'vue/no-unused-refs': 'warn',
+      'vue/no-unused-refs': 'error',
       'vue/no-use-v-else-with-v-for': 'error',
       'vue/no-useless-mustaches': 'warn',
       'vue/no-useless-v-bind': 'warn',

--- a/src/components/ProjectSelectionTable.vue
+++ b/src/components/ProjectSelectionTable.vue
@@ -25,7 +25,6 @@ function onPageChange(event: DataTablePageEvent): void {
 
 <template>
   <DataTable
-    ref="dt"
     :value="projectStore.projects"
     scrollable
     :loading="isLoading"


### PR DESCRIPTION
Done:
- ["unused-refs" changed from 'warn' to 'error'](https://github.com/remsfal/remsfal-frontend/issues/211)
- removed unused ref 'dt' on ProjectSelectionTable.vue

_Before updating ESLint:_
<img width="523" alt="Screenshot 2024-11-17 at 21 25 58" src="https://github.com/user-attachments/assets/78821ffc-de49-4071-8d8c-4e48890720f2">


_After updating ESLint:_
<img width="858" alt="Screenshot 2024-11-17 at 21 26 29" src="https://github.com/user-attachments/assets/9d724899-5031-44d4-bc43-c5b95fb5afe8">



