### PR TITLE
issue 212 warn to error-no-unused-vars/typescript-eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,7 +27,7 @@ export default [
   ...ts.configs.recommended,
   {
     rules: {
-      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-unused-vars': 'error',
       '@typescript-eslint/no-explicit-any': 'warn',
     },
   },


### PR DESCRIPTION
@typescript-eslint/no-unused-vars': 'error' instead of 'warm'