### PR TITLE
feat(i18n): add translations for property and unit view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/vue-fontawesome": "^3.0.8",
         "@primevue/themes": "^4.2.4",
-        "@rollup/rollup-linux-x64-gnu": "4.40.2",
         "axios": "^1.8.4",
         "chart.js": "4.4.8",
         "idb": "^8.0.2",

--- a/src/components/NewPropertyButton.vue
+++ b/src/components/NewPropertyButton.vue
@@ -48,7 +48,7 @@ const createProperty = async () => {
   <Button
     type="button"
     icon="pi pi-plus"
-    label="Grundstück hinzufügen"
+    :label="t('button.addProperty')"
     severity="success"
     @click="visible = true"
   />
@@ -56,7 +56,7 @@ const createProperty = async () => {
   <Dialog
     v-model:visible="visible"
     modal
-    header="Grundstück hinzufügen"
+    :header="t('button.addProperty')"
     :style="{ width: '35rem' }"
   >
     <div class="flex items-center gap-6 mb-6">

--- a/src/components/NewPropertyButton.vue
+++ b/src/components/NewPropertyButton.vue
@@ -48,7 +48,7 @@ const createProperty = async () => {
   <Button
     type="button"
     icon="pi pi-plus"
-    :label="t('button.addProperty')"
+    :label="t('rentableUnits.button.addProperty')"
     severity="success"
     @click="visible = true"
   />
@@ -56,7 +56,7 @@ const createProperty = async () => {
   <Dialog
     v-model:visible="visible"
     modal
-    :header="t('button.addProperty')"
+    :header="t('rentableUnits.button.addProperty')"
     :style="{ width: '35rem' }"
   >
     <div class="flex items-center gap-6 mb-6">

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -113,5 +113,22 @@
   "taskView.update.title": "Update Aufgabe mit ID: { id }",
   "property.descripton": "Beschreibung",
   "proppertty.area": "Grundstücksfläche",
-  "laoding": "Lade ..."
+  "laoding": "Lade ...",
+  "viewTitle": "Objektdaten Ansicht",
+  "table": {
+    "title": "Titel",
+    "type": "Typ",
+    "description": "Beschreibung",
+    "tenant": "Mieter",
+    "area": "Fläche"
+  },
+  "button": {
+    "addProperty": "Grundstück hinzufügen",
+    "expandAll": "Alle ausklappen",
+    "collapseAll": "Alle einklappen"
+  }
+
+
+
+
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -114,19 +114,21 @@
   "property.descripton": "Beschreibung",
   "proppertty.area": "Grundstücksfläche",
   "laoding": "Lade ...",
-  "viewTitle": "Objektdaten Ansicht",
-  "table": {
-    "title": "Titel",
-    "type": "Typ",
-    "description": "Beschreibung",
-    "tenant": "Mieter",
-    "area": "Fläche"
-  },
-  "button": {
-    "addProperty": "Grundstück hinzufügen",
-    "expandAll": "Alle ausklappen",
-    "collapseAll": "Alle einklappen"
-  }
+  "rentableUnits.view.title": "Objektdaten Ansicht",
+  "rentableUnits.button.addProperty": "Grundstück hinzufügen",
+  "rentableUnits.button.expandAll": "Alle ausklappen",
+  "rentableUnits.button.collapseAll": "Alle einklappen",
+  "rentableUnits.button.cancel": "Abbrechen",
+  "rentableUnits.button.confirmAdd": "Hinzufügen",
+  "rentableUnits.form.title": "Titel",
+  "rentableUnits.form.description": "Beschreibung",
+  "rentableUnits.form.titlePlaceholder": "Titel der neuen Einheit",
+  "rentableUnits.form.titleRequired": "Titel ist ein Pflichtfeld!",
+  "rentableUnits.table.title": "Titel",
+  "rentableUnits.table.type": "Typ",
+  "rentableUnits.table.description": "Beschreibung",
+  "rentableUnits.table.tenant": "Mieter",
+  "rentableUnits.table.area": "Fläche"
 
 
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -113,5 +113,24 @@
   "taskView.update.title": "Update Task with ID: { id }",
   "property.descripton": "Description",
   "proppertty.area": "Propperty Area",
-  "laoding": "Loading ..."
+  "laoding": "Loading ...",
+  "viewTitle": "Object Data View",
+  "table": {
+    "title": "Title",
+    "type": "Type",
+    "description": "Description",
+    "tenant": "Tenant",
+    "area": "Area"
+  },
+  "button": {
+    "addProperty": "Add Property",
+    "expandAll": "Expand all",
+    "collapseAll": "Collapse all"
+  }
+
+
+
+
 }
+
+

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -114,19 +114,16 @@
   "property.descripton": "Description",
   "proppertty.area": "Propperty Area",
   "laoding": "Loading ...",
-  "viewTitle": "Object Data View",
-  "table": {
-    "title": "Title",
-    "type": "Type",
-    "description": "Description",
-    "tenant": "Tenant",
-    "area": "Area"
-  },
-  "button": {
-    "addProperty": "Add Property",
-    "expandAll": "Expand all",
-    "collapseAll": "Collapse all"
-  }
+  "rentableUnits.button.addProperty": "Add Property",
+  "rentableUnits.button.expandAll": "Expand all",
+  "rentableUnits.button.collapseAll": "Collapse all",
+  "rentableUnits.table.title": "Title",
+  "rentableUnits.table.type": "Type",
+  "rentableUnits.table.description": "Description",
+  "rentableUnits.table.tenant": "Tenant",
+  "rentableUnits.table.area": "Area",
+  "rentableUnits.view.title": "Object Data View"
+
 
 
 

--- a/src/views/RentableUnitsView.vue
+++ b/src/views/RentableUnitsView.vue
@@ -9,6 +9,8 @@ import {
 import { useRouter } from 'vue-router';
 import Button from 'primevue/button';
 import Column from 'primevue/column';
+import { useI18n } from 'vue-i18n';
+
 import TreeTable, {
   type TreeTableExpandedKeys,
   type TreeTableSelectionKeys,
@@ -20,7 +22,7 @@ import NewPropertyButton from '@/components/NewPropertyButton.vue';
 const props = defineProps<{
   projectId: string;
 }>();
-
+const { t } = useI18n();
 const toast = useToast();
 
 const rentableUnitTree = ref<RentableUnitTreeNode[]>();
@@ -145,7 +147,7 @@ const onDeleteNode = (node: RentableUnitTreeNode) => {
 <template>
   <main>
     <div class="grid grid-cols-12 gap-4">
-      <h1>Objektdaten Ansicht</h1>
+      <h1>{{ t('viewTitle') }}</h1>
       <div v-if="error" class="alert alert-error">{{ error }}</div>
       <div v-if="!error" class="col-span-12">
         <div class="card">
@@ -164,44 +166,51 @@ const onDeleteNode = (node: RentableUnitTreeNode) => {
                 <div>
                   <Button
                     icon="pi pi-plus"
-                    label="Alle ausklappen"
+                    :label="t('button.expandAll')"
                     class="mr-2 mb-2"
                     @click="expandAll()"
                   />
                   <Button
                     icon="pi pi-minus"
-                    label="Alle einklappen"
+                    :label="t('button.collapseAll')"
                     class="mr-2 mb-2"
                     @click="collapseAll()"
                   />
+
                 </div>
               </div>
             </template>
-            <Column field="title" header="Title" expander>
+            <Column field="title" :header="t('table.title')" expander>
               <template #body="{ node }">
                 <div>{{ node.data.title }}</div>
               </template>
             </Column>
-            <Column field="type" header="Typ">
+
+            <Column field="type" :header="t('table.type')">
               <template #body="{ node }">
                 <div>{{ node.data.type }}</div>
               </template>
             </Column>
-            <Column field="description" header="Beschreibung">
+
+            <Column field="description" :header="t('table.description')">
               <template #body="{ node }">
                 <div>{{ node.data.description }}</div>
               </template>
             </Column>
-            <Column field="tenant" header="Mieter">
+
+            <Column field="tenant" :header="t('table.tenant')">
               <template #body="{ node }">
                 <div>{{ node.data.tenant }}</div>
               </template>
             </Column>
-            <Column field="usable_space" header="Fläche">
+
+            <Column field="usable_space" :header="t('table.area')">
               <template #body="{ node }">
                 <div>{{ node.data.usable_space }}</div>
               </template>
             </Column>
+
+
             <Column frozen alignFrozen="right">
               <template #body="{ node }">
                 <div class="flex flex-wrap gap-2">

--- a/src/views/RentableUnitsView.vue
+++ b/src/views/RentableUnitsView.vue
@@ -147,7 +147,7 @@ const onDeleteNode = (node: RentableUnitTreeNode) => {
 <template>
   <main>
     <div class="grid grid-cols-12 gap-4">
-      <h1>{{ t('viewTitle') }}</h1>
+      <h1>{{ t('rentableUnits.view.title') }}</h1>
       <div v-if="error" class="alert alert-error">{{ error }}</div>
       <div v-if="!error" class="col-span-12">
         <div class="card">
@@ -166,13 +166,13 @@ const onDeleteNode = (node: RentableUnitTreeNode) => {
                 <div>
                   <Button
                     icon="pi pi-plus"
-                    :label="t('button.expandAll')"
+                    :label="t('rentableUnits.button.expandAll')"
                     class="mr-2 mb-2"
                     @click="expandAll()"
                   />
                   <Button
                     icon="pi pi-minus"
-                    :label="t('button.collapseAll')"
+                    :label="t('rentableUnits.button.collapseAll')"
                     class="mr-2 mb-2"
                     @click="collapseAll()"
                   />
@@ -180,31 +180,31 @@ const onDeleteNode = (node: RentableUnitTreeNode) => {
                 </div>
               </div>
             </template>
-            <Column field="title" :header="t('table.title')" expander>
+            <Column field="title" :header="t('rentableUnits.table.title')" expander>
               <template #body="{ node }">
                 <div>{{ node.data.title }}</div>
               </template>
             </Column>
 
-            <Column field="type" :header="t('table.type')">
+            <Column field="type" :header="t('rentableUnits.table.type')">
               <template #body="{ node }">
                 <div>{{ node.data.type }}</div>
               </template>
             </Column>
 
-            <Column field="description" :header="t('table.description')">
+            <Column field="description" :header="t('rentableUnits.table.description')">
               <template #body="{ node }">
                 <div>{{ node.data.description }}</div>
               </template>
             </Column>
 
-            <Column field="tenant" :header="t('table.tenant')">
+            <Column field="tenant" :header="t('rentableUnits.table.tenant')">
               <template #body="{ node }">
                 <div>{{ node.data.tenant }}</div>
               </template>
             </Column>
 
-            <Column field="usable_space" :header="t('table.area')">
+            <Column field="usable_space" :header="t('rentableUnits.table.area')">
               <template #body="{ node }">
                 <div>{{ node.data.usable_space }}</div>
               </template>

--- a/test/views/RentableUnitsView.spec.ts
+++ b/test/views/RentableUnitsView.spec.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import ObjectDataView from '../../src/views/RentableUnitsView.vue';
 import { EntityType, propertyService } from '../../src/services/PropertyService';
 
+
+
 vi.mock('@/services/PropertyService');
 
 // Mock data
@@ -169,7 +171,8 @@ describe('ObjectDataView', () => {
 
     const columnHeaderRow = rows.find((row) => row.find('th'));
     expect(columnHeaderRow).not.toBeUndefined();
-    expect(columnHeaderRow.text()).toContain('TitleTypBeschreibungMieterFläche');
+    expect(columnHeaderRow.text()).toContain('TitelTypBeschreibungMieterFläche');
+
 
     // Validate the data rows
     const propertyRow1 = rows[1];


### PR DESCRIPTION
Übersetzung der Tabellenüberschriften:
Titel, Typ, Beschreibung, Mieter, Fläche

Übersetzung der Aktions-Buttons:
Alle ausklappen, Alle einklappen, Grundstück hinzufügen

Verwendung von vue-i18n mit de.json, en, json 

Beim Umschalten der Sprache werden die relevanten Texte in der jeweils gewählten Sprache angezeigt. 
(Vorher nur deutsch, auch wenn wir die Seite auf Englisch anzeigen wollten), jetzt aber auch in Englisch.