### PR TITLE
Anpassung Mietvertragsdarstellung für den Mieter, damit bei mehreren Mietverträgen diese nicht nebeneinander dargestellt werden

### DIFF
--- a/src/features/tenant/tenancies/components/TenancieContractList.vue
+++ b/src/features/tenant/tenancies/components/TenancieContractList.vue
@@ -48,8 +48,7 @@ onMounted(loadContracts);
         {{ error }}
       </Message>
 
-       <div v-if="contracts.length" class="mt-6 grid content-start gap-5" 
-       	style="grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));">
+       <div v-if="contracts.length" class="mt-6 grid content-start gap-5">
         <TenancieContractCard
           v-for="contract in contracts"
           :key="contract.agreementId"


### PR DESCRIPTION
Damit bei mehreren Verträgen diese nicht nebeneinander dargestellt werden.