### PR TITLE
Remove dead code from viewHelper.ts and add test coverage

### DIFF
--- a/src/components/common/BaseCard.vue
+++ b/src/components/common/BaseCard.vue
@@ -66,5 +66,3 @@ const cardClasses = computed(() => {
     <slot />
   </Card>
 </template>
-
-<style scoped></style>

--- a/src/features/manager/projects/components/NewProjectDialog.vue
+++ b/src/features/manager/projects/components/NewProjectDialog.vue
@@ -161,7 +161,3 @@ function abort() {
     </Form>
   </BaseDialog>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/helper/viewHelper.ts
+++ b/src/helper/viewHelper.ts
@@ -1,6 +1,4 @@
 import type { ToastServiceMethods } from 'primevue/toastservice';
-import type { Router } from 'vue-router';
-import type { Ref } from 'vue';
 
 export function showSavingErrorToast(toast: ToastServiceMethods, detail: string, err?: unknown) {
   toast.add({
@@ -9,49 +7,4 @@ export function showSavingErrorToast(toast: ToastServiceMethods, detail: string,
     detail: err ? `${detail}\n${String(err)}` : detail,
     life: 6000,
   });
-}
-
-export function showValidationErrorToast(toast: ToastServiceMethods, details: string[]) {
-  toast.add({
-    severity: 'error',
-    summary: 'Validierungsfehler',
-    detail: details.join('\n'),
-    life: 6000,
-  });
-}
-
-export function navigateToObjects(router: Router, projectId: string) {
-  router.push({ name: 'RentableUnits', params: { projectId } });
-}
-
-/**
- * Normalizes a value for comparison by treating empty strings, null, and undefined as equivalent.
- * This prevents false positives when comparing form values with original values.
- */
-export function normalizeValue(value: string | number | null | undefined): string | number | null {
-  if (value === undefined || value === '' || value === null) {
-    return null;
-  }
-  return value;
-}
-
-/**
- * Compares two values for equality, treating empty strings, null, and undefined as equivalent.
- */
-export function valuesAreEqual(a: string | number | null | undefined, b: string | number | null | undefined): boolean {
-  return normalizeValue(a) === normalizeValue(b);
-}
-
-export function handleCancel(hasChanges: Ref<boolean>, router: Router, projectId: string) {
-  if (hasChanges.value) {
-    const confirmLeave = confirm(
-      'Es gibt ungespeicherte Änderungen. Möchten Sie die Seite wirklich verlassen?',
-    );
-    if (!confirmLeave) return;
-  }
-  if (window.opener) {
-    window.close();
-  } else {
-    navigateToObjects(router, projectId);
-  }
 }

--- a/test/components/ContractorTable.spec.ts
+++ b/test/components/ContractorTable.spec.ts
@@ -45,7 +45,7 @@ describe('ContractorTable.vue', () => {
     expect(wrapper.findComponent(DataTable).props('value')).toEqual(mockIssues);
 
     const rows = wrapper.findAll('tr');
-    expect(rows.length).toBe(mockIssues.length + 1);
+    expect(rows).toHaveLength(mockIssues.length + 1);
   });
 
   it('expands a row when expander is clicked', async () => {

--- a/test/components/inbox/InboxSidebar.spec.ts
+++ b/test/components/inbox/InboxSidebar.spec.ts
@@ -89,7 +89,7 @@ describe('InboxSidebar', () => {
       messages: [],
     });
     const badges = wrapper.findAllComponents({ name: 'Badge' });
-    expect(badges.length).toBe(0);
+    expect(badges).toHaveLength(0);
   });
 
   it('emits update:activeNavItem when inbox button is clicked', async () => {

--- a/test/features/common/organizations/components/OrganizationEmployeeCard.spec.ts
+++ b/test/features/common/organizations/components/OrganizationEmployeeCard.spec.ts
@@ -85,7 +85,7 @@ describe('OrganizationEmployeeCard', () => {
     const wrapper = mountCard();
     await flushPromises();
     const selects = wrapper.findAllComponents({ name: 'EmployeeRoleSelect' });
-    expect(selects.length).toBe(mockEmployees.length);
+    expect(selects).toHaveLength(mockEmployees.length);
   });
 
   it('renders NewOrganizationEmployeeButton', async () => {

--- a/test/features/project/issues/components/IssueTable.spec.ts
+++ b/test/features/project/issues/components/IssueTable.spec.ts
@@ -48,7 +48,7 @@ describe('IssueTable', () => {
     expect(dataTable.exists()).toBe(true);
 
     const rows = wrapper.findAll('.p-datatable-tbody > tr');
-    expect(rows.length).toBe(mockIssues.length);
+    expect(rows).toHaveLength(mockIssues.length);
   });
 
   it('displays correct data for each column, resolving assignee names', () => {

--- a/test/features/project/rentableUnits/components/ApartmentDataCard.spec.ts
+++ b/test/features/project/rentableUnits/components/ApartmentDataCard.spec.ts
@@ -30,9 +30,7 @@ vi.mock('@/services/ApartmentService', () => ({apartmentService: { getApartment:
 // ─── viewHelper Mock ──────────────────────────────────────────────────────────
 vi.mock('@/helper/viewHelper', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/helper/viewHelper')>();
-  return {
-    ...actual, navigateToObjects: vi.fn(), showSavingErrorToast: vi.fn(),
-  };
+  return {...actual, showSavingErrorToast: vi.fn(),};
 });
 
 // ─── Test Data ────────────────────────────────────────────────────────────────

--- a/test/features/project/rentableUnits/components/BuildingDataCard.spec.ts
+++ b/test/features/project/rentableUnits/components/BuildingDataCard.spec.ts
@@ -30,9 +30,7 @@ vi.mock('@/services/BuildingService', () => ({buildingService: { getBuilding: vi
 // ─── viewHelper Mock ──────────────────────────────────────────────────────────
 vi.mock('@/helper/viewHelper', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/helper/viewHelper')>();
-  return {
-    ...actual, navigateToObjects: vi.fn(), showSavingErrorToast: vi.fn() 
-  };
+  return {...actual, showSavingErrorToast: vi.fn()};
 });
 
 // ─── Test Data ────────────────────────────────────────────────────────────────

--- a/test/features/project/rentableUnits/components/CommercialDataCard.spec.ts
+++ b/test/features/project/rentableUnits/components/CommercialDataCard.spec.ts
@@ -30,9 +30,7 @@ vi.mock('@/services/CommercialService', () => ({commercialService: { getCommerci
 // ─── viewHelper Mock ──────────────────────────────────────────────────────────
 vi.mock('@/helper/viewHelper', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/helper/viewHelper')>();
-  return {
-    ...actual, navigateToObjects: vi.fn(), showSavingErrorToast: vi.fn(),
-  };
+  return {...actual, showSavingErrorToast: vi.fn(),};
 });
 
 // ─── Test Data ────────────────────────────────────────────────────────────────

--- a/test/features/project/rentableUnits/components/PropertyDataCard.spec.ts
+++ b/test/features/project/rentableUnits/components/PropertyDataCard.spec.ts
@@ -29,9 +29,7 @@ vi.mock('@/services/PropertyService', () => ({propertyService: { getProperty: vi
 // ─── viewHelper Mock ──────────────────────────────────────────────────────────
 vi.mock('@/helper/viewHelper', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/helper/viewHelper')>();
-  return {
-    ...actual, navigateToObjects: vi.fn(), showSavingErrorToast: vi.fn() 
-  };
+  return {...actual, showSavingErrorToast: vi.fn()};
 });
 
 // ─── Test Data ────────────────────────────────────────────────────────────────

--- a/test/features/project/rentableUnits/components/SiteDataCard.spec.ts
+++ b/test/features/project/rentableUnits/components/SiteDataCard.spec.ts
@@ -30,9 +30,7 @@ vi.mock('@/services/SiteService', () => ({ siteService: { getSite: vi.fn(), upda
 // ─── viewHelper Mock ──────────────────────────────────────────────────────────
 vi.mock('@/helper/viewHelper', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/helper/viewHelper')>();
-  return {
-    ...actual, navigateToObjects: vi.fn(), showSavingErrorToast: vi.fn(),
-  };
+  return {...actual, showSavingErrorToast: vi.fn(),};
 });
 
 // ─── Test Data ────────────────────────────────────────────────────────────────

--- a/test/features/project/rentableUnits/components/StorageDataCard.spec.ts
+++ b/test/features/project/rentableUnits/components/StorageDataCard.spec.ts
@@ -30,9 +30,7 @@ vi.mock('@/services/StorageService', () => ({storageService: { getStorage: vi.fn
 // ─── viewHelper Mock ──────────────────────────────────────────────────────────
 vi.mock('@/helper/viewHelper', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/helper/viewHelper')>();
-  return {
-    ...actual, navigateToObjects: vi.fn(), showSavingErrorToast: vi.fn(),
-  };
+  return {...actual, showSavingErrorToast: vi.fn(),};
 });
 
 // ─── Test Data ────────────────────────────────────────────────────────────────

--- a/test/features/project/rentalAgreements/components/RentalDetailsForm.spec.ts
+++ b/test/features/project/rentalAgreements/components/RentalDetailsForm.spec.ts
@@ -24,7 +24,7 @@ describe('RentalDetailsForm', () => {
     expect(wrapper.find('input[name="operatingCostsPrepayment"]').exists()).toBe(true);
     expect(wrapper.find('input[name="heatingCostsPrepayment"]').exists()).toBe(true);
     expect(wrapper.findComponent({ name: 'SelectButton' }).exists()).toBe(true);
-    expect(wrapper.findAllComponents({ name: 'DatePicker' }).length).toBe(2);
+    expect(wrapper.findAllComponents({ name: 'DatePicker' })).toHaveLength(2);
   });
 
   it('has required field indicator for billing cycle', () => {
@@ -56,7 +56,7 @@ describe('RentalDetailsForm', () => {
 
   it('has date pickers for first and last payment', () => {
     const datePickers = wrapper.findAllComponents({ name: 'DatePicker' });
-    expect(datePickers.length).toBe(2);
+    expect(datePickers).toHaveLength(2);
   });
 
   it('displays unit type correctly', () => {
@@ -78,7 +78,7 @@ describe('RentalDetailsForm', () => {
     });
 
     const datePickers = wrapperWithDates.findAllComponents({ name: 'DatePicker' });
-    expect(datePickers.length).toBe(2);
+    expect(datePickers).toHaveLength(2);
   });
 
   it('has submit button with correct label', () => {

--- a/test/features/project/rentalAgreements/components/Step2UnitsForm.spec.ts
+++ b/test/features/project/rentalAgreements/components/Step2UnitsForm.spec.ts
@@ -92,7 +92,7 @@ describe('Step2UnitsForm', () => {
     await wrapper.vm.$nextTick();
 
     const unitCards = wrapper.findAll('.bg-gray-50');
-    expect(unitCards.length).toBe(1);
+    expect(unitCards).toHaveLength(1);
     expect(unitCards[0].text()).toContain('Apartment 101');
     expect(unitCards[0].text()).toContain('1.000,00');
   });

--- a/test/features/project/rentalAgreements/components/Step3TenantsForm.spec.ts
+++ b/test/features/project/rentalAgreements/components/Step3TenantsForm.spec.ts
@@ -117,7 +117,7 @@ describe('Step3TenantsForm', () => {
     await wrapper.vm.$nextTick();
 
     const tenantCards = wrapper.findAll('.bg-gray-50');
-    expect(tenantCards.length).toBe(2);
+    expect(tenantCards).toHaveLength(2);
     expect(tenantCards[0].text()).toContain('Max Mustermann');
     expect(tenantCards[1].text()).toContain('Erika Musterfrau');
   });

--- a/test/helper/viewHelper.spec.ts
+++ b/test/helper/viewHelper.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { showSavingErrorToast } from '@/helper/viewHelper';
+import type { ToastServiceMethods } from 'primevue/toastservice';
+
+describe('viewHelper', () => {
+  describe('showSavingErrorToast', () => {
+    it('shows an error toast without appending err when err is not provided', () => {
+      const toast = { add: vi.fn() } as unknown as ToastServiceMethods;
+
+      showSavingErrorToast(toast, 'Etwas ist schiefgelaufen');
+
+      expect(toast.add).toHaveBeenCalledWith({
+        severity: 'error',
+        summary: 'Speicherfehler',
+        detail: 'Etwas ist schiefgelaufen',
+        life: 6000,
+      });
+    });
+
+    it('appends the stringified err to detail when err is an Error instance', () => {
+      const toast = { add: vi.fn() } as unknown as ToastServiceMethods;
+
+      showSavingErrorToast(toast, 'Etwas ist schiefgelaufen', new Error('boom'));
+
+      expect(toast.add).toHaveBeenCalledWith(
+        expect.objectContaining({detail: 'Etwas ist schiefgelaufen\nError: boom',}),
+      );
+    });
+
+    it('appends the stringified err to detail when err is a plain string', () => {
+      const toast = { add: vi.fn() } as unknown as ToastServiceMethods;
+
+      showSavingErrorToast(toast, 'Etwas ist schiefgelaufen', 'network timeout');
+
+      expect(toast.add).toHaveBeenCalledWith(
+        expect.objectContaining({detail: 'Etwas ist schiefgelaufen\nnetwork timeout',}),
+      );
+    });
+  });
+});

--- a/test/layouts/ProjectMenu.spec.ts
+++ b/test/layouts/ProjectMenu.spec.ts
@@ -31,7 +31,7 @@ describe('ProjectMenu.vue', () => {
     wrapper = mountMenu();
     await wrapper.vm.$nextTick();
     const rootItems = wrapper.findAll('.layout-root-menuitem');
-    expect(rootItems.length).toBe(4);
+    expect(rootItems).toHaveLength(4);
   });
 
   it('renders section labels', async () => {

--- a/test/layouts/TenantMenu.spec.ts
+++ b/test/layouts/TenantMenu.spec.ts
@@ -17,7 +17,7 @@ describe('TenantMenu.vue', () => {
   it('renders three root menu sections', async () => {
     await wrapper.vm.$nextTick();
     const rootItems = wrapper.findAll('.layout-root-menuitem');
-    expect(rootItems.length).toBe(3);
+    expect(rootItems).toHaveLength(3);
   });
 
   it('renders "Mietverhältnisse" as the first section label', async () => {
@@ -41,19 +41,19 @@ describe('TenantMenu.vue', () => {
   it('renders two submenu items under "Mietverhältnisse"', async () => {
     await wrapper.vm.$nextTick();
     const submenus = wrapper.findAll('.layout-submenu');
-    expect(submenus[0].findAll('.layout-menuitem-text').length).toBe(2);
+    expect(submenus[0].findAll('.layout-menuitem-text')).toHaveLength(2);
   });
 
   it('renders one submenu item under "Einstellungen"', async () => {
     await wrapper.vm.$nextTick();
     const submenus = wrapper.findAll('.layout-submenu');
-    expect(submenus[1].findAll('.layout-menuitem-text').length).toBe(1);
+    expect(submenus[1].findAll('.layout-menuitem-text')).toHaveLength(1);
   });
 
   it('renders two submenu items under "Weitere Leistungen"', async () => {
     await wrapper.vm.$nextTick();
     const submenus = wrapper.findAll('.layout-submenu');
-    expect(submenus[2].findAll('.layout-menuitem-text').length).toBe(2);
+    expect(submenus[2].findAll('.layout-menuitem-text')).toHaveLength(2);
   });
 
   it('renders expected submenu item labels', async () => {

--- a/test/mocks/handlers/project.handlers.ts
+++ b/test/mocks/handlers/project.handlers.ts
@@ -6,8 +6,8 @@ export const projectHandlers = [
   // GET projects list
   http.get(`${API_BASE}/projects`, ({ request }) => {
     const url = new URL(request.url);
-    const offset = parseInt(url.searchParams.get('offset') || '0');
-    const limit = parseInt(url.searchParams.get('limit') || '10');
+    const offset = Number.parseInt(url.searchParams.get('offset') || '0');
+    const limit = Number.parseInt(url.searchParams.get('limit') || '10');
 
     return HttpResponse.json({
       projects: [

--- a/test/mocks/handlers/site.handlers.ts
+++ b/test/mocks/handlers/site.handlers.ts
@@ -33,7 +33,7 @@ export const siteHandlers = [
         id: 'new-site-id',
         projectId: params.projectId,
         propertyId: params.propertyId,
-        ...(lastRequests.createdSite ?? {}),
+        ...lastRequests.createdSite,
       });
     },
   ),
@@ -43,7 +43,7 @@ export const siteHandlers = [
     lastRequests.updatedSite = (await request.json()) as Record<string, unknown> | null;
     return HttpResponse.json({
       id: params.siteId,
-      ...(lastRequests.updatedSite ?? {}),
+      ...lastRequests.updatedSite,
     });
   }),
 

--- a/test/mocks/handlers/task.handlers.ts
+++ b/test/mocks/handlers/task.handlers.ts
@@ -47,14 +47,14 @@ export const taskHandlers = [
   // POST create task
   http.post(`${API_BASE}/projects/:projectId/tasks`, async ({ request }) => {
     const body = (await request.json()) as Record<string, unknown> | undefined;
-    lastRequests.createdTask = { ...(body ?? {}), id: 'new-task-id' };
+    lastRequests.createdTask = { ...body, id: 'new-task-id' };
     return HttpResponse.json(lastRequests.createdTask);
   }),
 
   // PATCH modify task
   http.patch(`${API_BASE}/projects/:projectId/tasks/:taskId`, async ({ request, params }) => {
     const body = (await request.json()) as Record<string, unknown> | undefined;
-    lastRequests.updatedTask = { id: params.taskId, ...(body ?? {}) };
+    lastRequests.updatedTask = { id: params.taskId, ...body };
     return HttpResponse.json(lastRequests.updatedTask);
   }),
 ];

--- a/test/views/contractor/ContractorDashboard.spec.ts
+++ b/test/views/contractor/ContractorDashboard.spec.ts
@@ -34,7 +34,7 @@ describe("ContractorDashboardView", () => {
   // ------------------------------------------------------------
   it("renders 4 KPI cards", () => {
     const wrapper = mountView();
-    expect(wrapper.findAll(".kpi-card").length).toBe(4);
+    expect(wrapper.findAll(".kpi-card")).toHaveLength(4);
   });
 
   it("renders all KPI card titles correctly", () => {
@@ -59,7 +59,7 @@ describe("ContractorDashboardView", () => {
   it("renders all 3 charts (bar, doughnut, line)", () => {
     const wrapper = mountView();
     const charts = wrapper.findAll('[data-test="chart-stub"]');
-    expect(charts.length).toBe(3);
+    expect(charts).toHaveLength(3);
   });
 
   // ------------------------------------------------------------

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -140,6 +140,11 @@ export default defineConfig({
     strictPort: true,
     port: 5173,
     host: '0.0.0.0',
+    watch: {
+      // Coverage reports (written mid-run by istanbul during `coverage:e2e`) mirror the
+      // src/ tree — without this, every report write triggers a full page reload.
+      ignored: ['**/coverage/**', '**/coverage-cypress/**', '**/coverage-vitest/**'],
+    },
     proxy: {
       '/api': createProxyConfig('http://localhost:8080', 'Platform Microservice'),
       '/ticketing': createProxyConfig('http://localhost:8081', 'Ticketing Microservice'),


### PR DESCRIPTION
showValidationErrorToast, navigateToObjects, normalizeValue, valuesAreEqual, and handleCancel had no callers anywhere in the codebase (built for a cancel/dirty-check flow in the RentableUnit DataCards that was never wired up). Only showSavingErrorToast is actually used, so it's the only export kept, now with unit tests. Updated the six DataCard specs whose viewHelper mock referenced the removed navigateToObjects export.